### PR TITLE
rate-web-20 Replace ApiResponse to ResponseEntity from Spring.

### DIFF
--- a/src/main/java/org/webtree/rate/web/model/ApiResponseStatus.java
+++ b/src/main/java/org/webtree/rate/web/model/ApiResponseStatus.java
@@ -2,6 +2,7 @@ package org.webtree.rate.web.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import org.springframework.http.HttpStatus;
 
 import java.net.HttpURLConnection;
 
@@ -14,44 +15,25 @@ public class ApiResponseStatus {
     @JsonInclude(Include.NON_EMPTY)
     private String message;
 
-    public static enum ApiStatusCode {
-        // General codes
-        OK(HttpURLConnection.HTTP_OK),
-        UNAUTHORIZED(HttpURLConnection.HTTP_UNAUTHORIZED),
-        PRECONDITION(HttpURLConnection.HTTP_PRECON_FAILED),
-        FORBIDDEN(HttpURLConnection.HTTP_FORBIDDEN),
-        ERROR(HttpURLConnection.HTTP_INTERNAL_ERROR);
-        private int code;
-
-        ApiStatusCode(int code) {
-            this.code = code;
-        }
-
-        public int getCode() {
-
-            return code;
-        }
-    }
-
     public static ApiResponseStatus getOkStatus() {
-        return new ApiResponseStatus(ApiStatusCode.OK);
+        return new ApiResponseStatus(HttpStatus.OK);
     }
 
     public static ApiResponseStatus getErrorStatus() {
-        return new ApiResponseStatus(ApiStatusCode.ERROR);
+        return new ApiResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
-    public static ApiResponseStatus getStatus(ApiStatusCode code) {
+    public static ApiResponseStatus getStatus(HttpStatus code) {
         return new ApiResponseStatus(code);
     }
 
-    public ApiResponseStatus(ApiStatusCode code, String message) {
-        this.code = code.getCode();
+    public ApiResponseStatus(HttpStatus code, String message) {
+        this.code = code.value();
         this.message = message;
     }
 
-    public ApiResponseStatus(ApiStatusCode code) {
-        this.code = code.getCode();
+    public ApiResponseStatus(HttpStatus code) {
+        this.code = code.value();
     }
 
     public String getMessage() {

--- a/src/main/java/org/webtree/rate/web/utils/ResponseUtil.java
+++ b/src/main/java/org/webtree/rate/web/utils/ResponseUtil.java
@@ -1,5 +1,6 @@
 package org.webtree.rate.web.utils;
 
+import org.springframework.http.HttpStatus;
 import org.webtree.rate.web.model.ApiResponse;
 import org.webtree.rate.web.model.ApiResponseStatus;
 
@@ -21,11 +22,11 @@ public final class ResponseUtil {
         return new ApiResponse<>(getOkStatus(), data);
     }
 
-    public static <T> ApiResponse<T> wrapResponse(ApiStatusCode code, String message) {
-        return new ApiResponse<>(new ApiResponseStatus(code, message));
+    public static <T> ApiResponse<T> wrapResponse(HttpStatus status, String message) {
+        return new ApiResponse<>(new ApiResponseStatus(status, message));
     }
 
-    public static <T> ApiResponse<T> wrapResponse(ApiStatusCode code, String message, T data) {
-        return new ApiResponse<>(new ApiResponseStatus(code, message), data);
+    public static <T> ApiResponse<T> wrapResponse(HttpStatus status, String message, T data) {
+        return new ApiResponse<>(new ApiResponseStatus(status, message), data);
     }
 }

--- a/src/main/resources/public/templates/app.html
+++ b/src/main/resources/public/templates/app.html
@@ -11,7 +11,7 @@
             <div class="collapse navbar-collapse navbar-right">
                 <ul class="nav navbar-nav">
                     <li *ngIf="!isAuth()">
-                        <a class="nav-link" (click)="username()">Login</a>
+                        <a class="nav-link" (click)="login()">Login</a>
                     </li>
                     <li *ngIf="getCurrentUser()">
                         <a class="nav-link" [routerLink]="['/user/details/', getCurrentUser().id]">


### PR DESCRIPTION
Just replaced ApiStatusCode to HttpStatus from spring. Using ResponseEntity is not useful now because of inside builder, which don't give opportunity to extend ResponseEntity.
